### PR TITLE
Adding MACRAW mode support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Add support for MACRAW operation mode [#33](https://github.com/kellerkindt/w5500/pull/33)
+
 ## [0.4.0] - January 22nd, 2022
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bus;
 mod device;
 mod host;
 pub mod net;
+pub mod raw_device;
 pub mod register;
 mod socket;
 pub mod tcp;

--- a/src/raw_device.rs
+++ b/src/raw_device.rs
@@ -1,0 +1,111 @@
+use crate::{bus::Bus, register, socket::Socket, uninitialized_device::InitializeError};
+
+/// The W5500 operating in MACRAW mode to send and receive ethernet frames.
+pub struct RawDevice<SpiBus: Bus> {
+    bus: SpiBus,
+    raw_socket: Socket,
+}
+
+impl<SpiBus: Bus> RawDevice<SpiBus> {
+    /// Create the raw device.
+    ///
+    /// # Note
+    /// The device is configured with MAC filtering enabled.
+    ///
+    /// # Args
+    /// * `bus` - The bus to communicate with the device.
+    pub(crate) fn new(mut bus: SpiBus) -> Result<Self, InitializeError<SpiBus::Error>> {
+        let raw_socket = Socket::new(0);
+
+        // Configure the chip in MACRAW mode with MAC filtering.
+        let mode: u8 = (1 << 7) | (register::socketn::Protocol::MacRaw as u8);
+
+        bus.write_frame(raw_socket.register(), register::socketn::MODE, &[mode])?;
+        raw_socket.command(&mut bus, register::socketn::Command::Open)?;
+
+        Ok(Self { bus, raw_socket })
+    }
+
+    /// Read an ethernet frame from the device.
+    ///
+    /// # Args
+    /// * `frame` - The location to store the received frame
+    ///
+    /// # Returns
+    /// The number of bytes read into the provided frame buffer.
+    pub fn read_frame(&mut self, frame: &mut [u8]) -> Result<usize, SpiBus::Error> {
+        if !self
+            .raw_socket
+            .has_interrupt(&mut self.bus, register::socketn::Interrupt::Receive)?
+        {
+            return Ok(0);
+        }
+
+        let rx_size = self.raw_socket.get_receive_size(&mut self.bus)? as usize;
+
+        let read_buffer = if rx_size > frame.len() {
+            frame
+        } else {
+            &mut frame[..rx_size]
+        };
+
+        // Read from the RX ring buffer.
+        let read_pointer = self.raw_socket.get_rx_read_pointer(&mut self.bus)?;
+        self.bus
+            .read_frame(self.raw_socket.rx_buffer(), read_pointer, read_buffer)?;
+        self.raw_socket.set_rx_read_pointer(
+            &mut self.bus,
+            read_pointer.wrapping_add(read_buffer.len() as u16),
+        )?;
+
+        // Register the reception as complete.
+        self.raw_socket
+            .command(&mut self.bus, register::socketn::Command::Receive)?;
+        self.raw_socket
+            .reset_interrupt(&mut self.bus, register::socketn::Interrupt::Receive)?;
+
+        Ok(read_buffer.len())
+    }
+
+    /// Write an ethernet frame to the device.
+    ///
+    /// # Args
+    /// * `frame` - The ethernet frame to transmit.
+    ///
+    /// # Returns
+    /// The number of bytes successfully transmitted from the provided buffer.
+    pub fn write_frame(&mut self, frame: &[u8]) -> Result<usize, SpiBus::Error> {
+        let max_size = self.raw_socket.get_tx_free_size(&mut self.bus)? as usize;
+
+        let write_data = if frame.len() < max_size {
+            frame
+        } else {
+            &frame[..max_size]
+        };
+
+        // Append the data to the write buffer after the current write pointer.
+        let write_pointer = self.raw_socket.get_tx_write_pointer(&mut self.bus)?;
+
+        // Write data into the buffer and update the writer pointer.
+        self.bus
+            .write_frame(self.raw_socket.tx_buffer(), write_pointer, write_data)?;
+        self.raw_socket.set_tx_write_pointer(
+            &mut self.bus,
+            write_pointer.wrapping_add(write_data.len() as u16),
+        )?;
+
+        // Wait for the socket transmission to complete.
+        self.raw_socket
+            .reset_interrupt(&mut self.bus, register::socketn::Interrupt::SendOk)?;
+
+        self.raw_socket
+            .command(&mut self.bus, register::socketn::Command::Send)?;
+
+        while !self
+            .raw_socket
+            .has_interrupt(&mut self.bus, register::socketn::Interrupt::SendOk)?
+        {}
+
+        Ok(write_data.len())
+    }
+}

--- a/src/raw_device.rs
+++ b/src/raw_device.rs
@@ -27,8 +27,7 @@ impl<SpiBus: Bus> RawDevice<SpiBus> {
             bus.write_frame(socket.register(), register::socketn::RXBUF_SIZE, &[0])?;
         }
 
-        // Configure the chip in MACRAW mode with MAC filtering + Multicast blocking + IPv6
-        // Blocking + Broadcast blocking.
+        // Configure the chip in MACRAW mode with MAC filtering.
         let mode: u8 = (1 << 7) | // MAC address filtering
                        (register::socketn::Protocol::MacRaw as u8);
 
@@ -38,6 +37,15 @@ impl<SpiBus: Bus> RawDevice<SpiBus> {
         Ok(Self { bus, raw_socket })
     }
 
+    // Read bytes from the RX buffer.
+    //
+    // # Args
+    // * `buffer` - The location to read data into. The length of this slice determines how much
+    // data is read.
+    // * `offset` - The offset into current RX data to start reading from in bytes.
+    //
+    // # Returns
+    // The number of bytes successfully read.
     fn read_bytes(&mut self, buffer: &mut [u8], offset: u16) -> Result<usize, SpiBus::Error> {
         let rx_size = self.raw_socket.get_receive_size(&mut self.bus)? as usize;
 

--- a/src/raw_device.rs
+++ b/src/raw_device.rs
@@ -105,8 +105,7 @@ impl<SpiBus: Bus> RawDevice<SpiBus> {
         self.raw_socket
             .command(&mut self.bus, register::socketn::Command::Receive)?;
 
-        // If we couldn't read the whole check sequence or if we read less bytes than expected,
-        // drop the frame.
+        // If we couldn't read the whole frame, drop it instead.
         if received_frame_size < expected_frame_size {
             Ok(0)
         } else {

--- a/src/register.rs
+++ b/src/register.rs
@@ -217,6 +217,10 @@ pub mod socketn {
 
     pub const DESTINATION_PORT: u16 = 0x10;
 
+    pub const RXBUF_SIZE: u16 = 0x1E;
+
+    pub const TXBUF_SIZE: u16 = 0x1F;
+
     pub const TX_FREE_SIZE: u16 = 0x20;
 
     pub const TX_DATA_READ_POINTER: u16 = 0x22;

--- a/src/register.rs
+++ b/src/register.rs
@@ -167,6 +167,7 @@ pub mod socketn {
         Closed = 0b00,
         Tcp = 0b01,
         Udp = 0b10,
+        MacRaw = 0b100,
     }
     pub const COMMAND: u16 = 0x01;
     #[repr(u8)]

--- a/src/uninitialized_device.rs
+++ b/src/uninitialized_device.rs
@@ -103,8 +103,13 @@ impl<SpiBus: Bus> UninitializedDevice<SpiBus> {
         mut self,
         mac: MacAddress,
     ) -> Result<RawDevice<SpiBus>, InitializeError<SpiBus::Error>> {
+        // Reset the device.
+        self.bus
+            .write_frame(register::COMMON, register::common::MODE, &[0x80])?;
+
         self.bus
             .write_frame(register::COMMON, register::common::MAC, &mac.octets)?;
+
         RawDevice::new(self.bus)
     }
 

--- a/src/uninitialized_device.rs
+++ b/src/uninitialized_device.rs
@@ -5,6 +5,7 @@ use embedded_nal::Ipv4Addr;
 use crate::bus::{Bus, FourWire, ThreeWire};
 use crate::device::Device;
 use crate::host::{Dhcp, Host, Manual};
+use crate::raw_device::RawDevice;
 use crate::register;
 use crate::{MacAddress, Mode};
 
@@ -96,6 +97,15 @@ impl<SpiBus: Bus> UninitializedDevice<SpiBus> {
         self.set_mode(mode_options)?;
         host.refresh(&mut self.bus)?;
         Ok(Device::new(self.bus, host))
+    }
+
+    pub fn initialize_macraw(
+        mut self,
+        mac: MacAddress,
+    ) -> Result<RawDevice<SpiBus>, InitializeError<SpiBus::Error>> {
+        self.bus
+            .write_frame(register::COMMON, register::common::MAC, &mac.octets)?;
+        RawDevice::new(self.bus)
     }
 
     #[cfg(not(feature = "no-chip-version-assertion"))]


### PR DESCRIPTION
This PR adds in initial MACRAW operation mode support. This allows you to run a software-based network stack (e.g. smoltcp) on socket 0.

The current implementation does not support any type of hybrid model (e.g. TCP/UDP on sockets 1-7, raw on socket 0), but rather allocates the whole RX/TX buffers for socket 0 in raw mode and disables the other sockets.

Using this, raw ethernet frames can be read from and written to the W5500 MAC.

I have used this branch with Smoltcp to implement multiple MQTT clients over TCP to confirm operation.