### PR TITLE
Enable hardware interrupts

### DIFF
--- a/src/register.rs
+++ b/src/register.rs
@@ -10,6 +10,7 @@ pub mod common {
     pub const SUBNET_MASK: u16 = 0x05;
     pub const MAC: u16 = 0x09;
     pub const IP: u16 = 0x0F;
+    pub const SOCKET_INTERRUPT_MASK: u16 = 0x0018;
     pub const PHY_CONFIG: u16 = 0x2E;
     pub const VERSION: u16 = 0x39;
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -37,7 +37,9 @@ impl TcpSocket {
 
         self.socket.set_interrupt_mask(
             bus,
-            socketn::Interrupt::SendOk as u8 & socketn::Interrupt::Timeout as u8,
+            socketn::Interrupt::SendOk as u8
+                | socketn::Interrupt::Timeout as u8
+                | socketn::Interrupt::Receive as u8,
         )?;
 
         self.socket.command(bus, socketn::Command::Open)?;
@@ -55,7 +57,9 @@ impl TcpSocket {
 
         self.socket.set_interrupt_mask(
             bus,
-            socketn::Interrupt::SendOk as u8 & socketn::Interrupt::Timeout as u8,
+            socketn::Interrupt::SendOk as u8
+                | socketn::Interrupt::Timeout as u8
+                | socketn::Interrupt::Receive as u8,
         )?;
 
         self.socket.command(bus, socketn::Command::Open)?;

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -26,7 +26,9 @@ impl UdpSocket {
         self.socket.set_mode(bus, socketn::Protocol::Udp)?;
         self.socket.set_interrupt_mask(
             bus,
-            socketn::Interrupt::SendOk as u8 & socketn::Interrupt::Timeout as u8,
+            socketn::Interrupt::SendOk as u8
+                | socketn::Interrupt::Timeout as u8
+                | socketn::Interrupt::Receive as u8,
         )?;
         self.socket.command(bus, socketn::Command::Open)?;
         Ok(())

--- a/src/uninitialized_device.rs
+++ b/src/uninitialized_device.rs
@@ -94,6 +94,12 @@ impl<SpiBus: Bus> UninitializedDevice<SpiBus> {
         self.bus
             .write_frame(register::COMMON, register::common::MODE, &mode)?;
 
+        self.bus.write_frame(
+            register::COMMON,
+            register::common::SOCKET_INTERRUPT_MASK,
+            &[0xFF],
+        )?;
+
         self.set_mode(mode_options)?;
         host.refresh(&mut self.bus)?;
         Ok(Device::new(self.bus, host))


### PR DESCRIPTION
I noticed no hardware interrupts being triggered on pin `INTn`. Fixed by:
* fixing the mask construction for the sockets from a bitwise AND `&` to bitwise OR `|`.
* enabling hardware interrupts for all sockets.

I am unsure whether enabling the hardware interrupts in the device initialization is the best location to do so, or whether it is better to fetch the current mask when using a specific socket and enabling interrupts only for the new socket.