### PR TITLE
Fix Udp, docs and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Additional checks for `UdpSocket` status when sending data by [@elpiel](https://github.com/elpiel) ([#42][PR42])
 - Additional checks for `UdpSocket` when sending data to validate that there has been a set destination by [@elpiel](https://github.com/elpiel) ([#42][PR42])
 - Add `RetryTime` value and `RetryCount`
+- export `DeviceState` in the API and introduce `Device::get_state`
+- Improve documentation for register and methods
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `UdpSocket.set_port` to set a new socket port by [@elpiel](https://github.com/elpiel) ([#42][PR42])
 - Additional checks for `UdpSocket` status when sending data by [@elpiel](https://github.com/elpiel) ([#42][PR42])
 - Additional checks for `UdpSocket` when sending data to validate that there has been a set destination by [@elpiel](https://github.com/elpiel) ([#42][PR42])
+- Add `RetryTime` value and `RetryCount`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `UdpSocket.set_port` to set a new socket port by [@elpiel](https://github.com/elpiel) ([#42][PR42])
 - Additional checks for `UdpSocket` status when sending data by [@elpiel](https://github.com/elpiel) ([#42][PR42])
 - Additional checks for `UdpSocket` when sending data to validate that there has been a set destination by [@elpiel](https://github.com/elpiel) ([#42][PR42])
-- Add `RetryTime` value and `RetryCount`
-- export `DeviceState` in the API and introduce `Device::get_state`
-- Improve documentation for register and methods
+- Add `RetryTime` value and `RetryCount` registers method by [@elpiel](https://github.com/elpiel) ([#42][PR42])
+- export `DeviceState` in the API and introduce `Device::get_state` by [@elpiel](https://github.com/elpiel) ([#42][PR42])
+- Improve documentation for register and methods by [@elpiel](https://github.com/elpiel) ([#42][PR42])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `defmt` features for enabling `defmt::Format` to most structs and errors by [@elpiel](https://github.com/elpiel) ([#39](https://github.com/kellerkindt/w5500/issues/39))
 - Fixed an issue where internal function names were conflicting with trait names by [@ryan-summers](https://github.com/ryan-summers) ([#36](https://github.com/kellerkindt/w5500/issues/36))
-- Tests for `FourWire` `Bus` implementation and internal `Socket` registers by [@elpiel](https://github.com/elpiel) ([#42](https://github.com/kellerkindt/w5500/issues/42))
+- Tests for `FourWire` `Bus` implementation and internal `Socket` registers by [@elpiel](https://github.com/elpiel) ([#42][PR42])
+- Added `UdpSocket.set_port` to set a new socket port by [@elpiel](https://github.com/elpiel) ([#42][PR42])
+- Additional checks for `UdpSocket` status when sending data by [@elpiel](https://github.com/elpiel) ([#42][PR42])
+- Additional checks for `UdpSocket` when sending data to validate that there has been a set destination by [@elpiel](https://github.com/elpiel) ([#42][PR42])
 
 ### Fixed
 
-- Udp socket sending and receiving using the ring buffers of `w5500` by [@elpiel](https://github.com/elpiel) ([#42](https://github.com/kellerkindt/w5500/issues/42))
+- Udp socket sending and receiving using the ring buffers for RX & TX of `w5500` by [@elpiel](https://github.com/elpiel) ([#42][PR42])
+
+[PR42]: https://github.com/kellerkindt/w5500/pull/42
 
 ## [0.4.1] - January 2nd, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `defmt` features for enabling `defmt::Format` to most structs and errors by [@elpiel](https://github.com/elpiel) ([#39](https://github.com/kellerkindt/w5500/issues/39))
+- Tests for `FourWire` `Bus` implementation and internal `Socket` registers by [@elpiel](https://github.com/elpiel) ([#42](https://github.com/kellerkindt/w5500/issues/42))
+
+### Fixed
+
+- Udp socket sending and receiving using the ring buffers of `w5500` by [@elpiel](https://github.com/elpiel) ([#42](https://github.com/kellerkindt/w5500/issues/42))
 
 ## [0.4.1] - January 2nd, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `UdpSocket.set_port` to set a new socket port by [@elpiel](https://github.com/elpiel) ([#42][PR42])
 - Additional checks for `UdpSocket` status when sending data by [@elpiel](https://github.com/elpiel) ([#42][PR42])
 - Additional checks for `UdpSocket` when sending data to validate that there has been a set destination by [@elpiel](https://github.com/elpiel) ([#42][PR42])
-- Add `RetryTime` value and `RetryCount` registers method by [@elpiel](https://github.com/elpiel) ([#42][PR42])
+- Add `RetryTime` value and `RetryCount` registers methods by [@elpiel](https://github.com/elpiel) ([#42][PR42])
 - export `DeviceState` in the API and introduce `Device::get_state` by [@elpiel](https://github.com/elpiel) ([#42][PR42])
 - Improve documentation for register and methods by [@elpiel](https://github.com/elpiel) ([#42][PR42])
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,18 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2018"
 
+[features]
+no-chip-version-assertion = []
+
 [dependencies]
 byteorder = { version = "1.3.4", default-features = false }
-embedded-hal = "0.2.4"
+embedded-hal = "0.2"
 embedded-nal = "0.6.0"
-bit_field = "0.10.1"
+bit_field = "0.10.2"
 derive-try-from-primitive = "1"
 nb = "1.0.0"
 defmt = { version = "0.3", optional = true }
 
-[features]
-no-chip-version-assertion = []
+[dev-dependencies]
+embedded-hal-mock = "0.9"
+defmt = { version = "0.3" }

--- a/src/bus/four_wire.rs
+++ b/src/bus/four_wire.rs
@@ -35,9 +35,6 @@ impl<Spi: Transfer<u8> + Write<u8>, ChipSelect: OutputPin> Bus for FourWire<Spi,
         let control_phase = block << 3;
         let data_phase = data;
 
-        #[cfg(feature = "defmt")]
-        defmt::debug!("Address: {:b}, control_phase: {:b}", address, control_phase);
-
         // set Chip select to Low, i.e. prepare to receive data
         self.cs.set_low().map_err(FourWireError::ChipSelectError)?;
         let result = (|| {
@@ -106,3 +103,91 @@ impl<TransferError, WriteError, ChipSelectError> fmt::Debug
 
 // TODO Improved error rendering could be done with specialization.
 // https://github.com/rust-lang/rust/issues/31844
+#[cfg(test)]
+mod test {
+    use defmt::unwrap;
+
+    use embedded_hal::digital::v2::OutputPin;
+    use embedded_hal_mock::{
+        pin::{Mock as PinMock, State as PinState, Transaction as PinTransaction},
+        spi::{Mock as SpiMock, Transaction as SpiTransaction},
+    };
+
+    use crate::{
+        bus::{four_wire::WRITE_MODE_MASK, Bus},
+        register,
+    };
+
+    use super::FourWire;
+
+    #[test]
+    fn test_read_frame() {
+        let mut cs_pin = PinMock::new(&[
+            // we begin with pin HIGH
+            PinTransaction::set(PinState::High),
+            // When reading
+            PinTransaction::set(PinState::Low),
+            // When finished reading
+            PinTransaction::set(PinState::High),
+        ]);
+
+        // initiate the pin to high.
+        cs_pin.set_high().expect("Should set pin to high");
+
+        let mut actual_version = [0_u8; 1];
+        let mut expected_version = 5;
+
+        let expectations = [
+            SpiTransaction::write(register::common::VERSION.to_be_bytes().to_vec()),
+            SpiTransaction::write(vec![register::COMMON << 3]),
+            SpiTransaction::transfer(actual_version.to_vec(), vec![expected_version]),
+        ];
+
+        let mock_spi = SpiMock::new(&expectations);
+
+        let mut four_wire = FourWire::new(mock_spi, cs_pin);
+
+        four_wire.read_frame(
+            register::COMMON,
+            register::common::VERSION,
+            &mut actual_version,
+        );
+
+        assert_eq!(expected_version, actual_version[0]);
+    }
+
+    #[test]
+    fn test_write_frame() {
+        let mut cs_pin = PinMock::new(&[
+            // we begin with pin HIGH
+            PinTransaction::set(PinState::High),
+            // When reading
+            PinTransaction::set(PinState::Low),
+            // When finished reading
+            PinTransaction::set(PinState::High),
+        ]);
+
+        // initiate the pin to high.
+        cs_pin.set_high().expect("Should set pin to high");
+
+        let socket_0_reg = 0x01_u8;
+        let socket_1_reg = 0x05_u8;
+        let source_port = 49849_u16;
+
+        let expectations = [
+            SpiTransaction::write(register::socketn::SOURCE_PORT.to_be_bytes().to_vec()),
+            SpiTransaction::write(vec![socket_1_reg << 3 | WRITE_MODE_MASK]),
+            SpiTransaction::write(source_port.to_be_bytes().to_vec()),
+        ];
+
+        let mock_spi = SpiMock::new(&expectations);
+
+        let mut four_wire = FourWire::new(mock_spi, cs_pin);
+
+        four_wire.write_frame(
+            socket_1_reg,
+            register::socketn::SOURCE_PORT,
+            &source_port.to_be_bytes(),
+        );
+    }
+}

--- a/src/bus/four_wire.rs
+++ b/src/bus/four_wire.rs
@@ -105,8 +105,6 @@ impl<TransferError, WriteError, ChipSelectError> fmt::Debug
 // https://github.com/rust-lang/rust/issues/31844
 #[cfg(test)]
 mod test {
-    use defmt::unwrap;
-
     use embedded_hal::digital::v2::OutputPin;
     use embedded_hal_mock::{
         pin::{Mock as PinMock, State as PinState, Transaction as PinTransaction},

--- a/src/bus/four_wire.rs
+++ b/src/bus/four_wire.rs
@@ -79,6 +79,7 @@ impl<Spi: Transfer<u8> + Write<u8>, ChipSelect: OutputPin> Bus for FourWire<Spi,
 
 // Must use map_err, ambiguity prevents From from being implemented
 #[repr(u8)]
+#[derive(Clone)]
 pub enum FourWireError<TransferError, WriteError, ChipSelectError> {
     TransferError(TransferError),
     WriteError(WriteError),

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -4,6 +4,11 @@ mod four_wire;
 mod four_wire_ref;
 mod three_wire;
 
+use crate::register::{
+    self,
+    common::{RetryCount, RetryTime},
+};
+
 pub use self::four_wire::FourWire;
 pub use self::four_wire::FourWireError;
 pub use self::four_wire_ref::FourWireRef;
@@ -18,6 +23,109 @@ pub trait Bus {
     fn read_frame(&mut self, block: u8, address: u16, data: &mut [u8]) -> Result<(), Self::Error>;
 
     fn write_frame(&mut self, block: u8, address: u16, data: &[u8]) -> Result<(), Self::Error>;
+
+    /// Reset the device
+    #[inline]
+    fn reset(&mut self) -> Result<(), Self::Error> {
+        self.write_frame(
+            register::COMMON,
+            register::common::MODE,
+            &register::common::Mode::Reset.to_register(),
+        )?;
+
+        Ok(())
+    }
+
+    #[inline]
+    fn set_mode(&mut self, mode_options: register::common::Mode) -> Result<(), Self::Error> {
+        self.write_frame(
+            register::COMMON,
+            register::common::MODE,
+            &mode_options.to_register(),
+        )?;
+        Ok(())
+    }
+
+    #[inline]
+    fn version(&mut self) -> Result<u8, Self::Error> {
+        let mut version_register = [0_u8];
+        self.read_frame(
+            register::COMMON,
+            register::common::VERSION,
+            &mut version_register,
+        )?;
+
+        Ok(version_register[0])
+    }
+
+    /// RTR (Retry Time-value Register) [R/W] [0x0019 – 0x001A] [0x07D0]
+    ///
+    /// # Example
+    /// ```
+    /// use w5500::register::common::RetryTime;
+    ///
+    /// let default = RetryTime::from_millis(200);
+    /// assert_eq!(RetryTime::default(), default);
+    ///
+    /// // E.g. 4000 (register) = 400ms
+    /// let four_hundred_ms = RetryTime::from_millis(400);
+    /// assert_eq!(four_hundred_ms.to_u16(), 4000);
+    /// ```
+    #[inline]
+    fn set_retry_timeout(&mut self, retry_time_value: RetryTime) -> Result<(), Self::Error> {
+        self.write_frame(
+            register::COMMON,
+            register::common::RETRY_TIME,
+            &retry_time_value.to_register(),
+        )?;
+
+        Ok(())
+    }
+
+    /// RTR (Retry Time-value Register) [R/W] [0x0019 – 0x001A] [0x07D0]
+    ///
+    /// E.g. 4000 = 400ms
+    #[inline]
+    fn current_retry_timeout(&mut self) -> Result<RetryTime, Self::Error> {
+        let mut retry_time_register: [u8; 2] = [0, 0];
+        self.read_frame(
+            register::COMMON,
+            register::common::RETRY_TIME,
+            &mut retry_time_register,
+        )?;
+
+        Ok(RetryTime::from_register(retry_time_register))
+    }
+
+    /// Set a new value for the Retry Count register.
+    ///
+    /// RCR (Retry Count Register) [R/W] [0x001B] [0x08]
+    fn set_retry_count(&mut self, retry_count: RetryCount) -> Result<(), Self::Error> {
+        self.write_frame(
+            register::COMMON,
+            register::common::RETRY_COUNT,
+            &retry_count.to_register(),
+        )?;
+
+        Ok(())
+    }
+
+    /// Get the current Retry Count value
+    /// RCR (Retry Count Register) [R/W] [0x001B] [0x08]
+    ///
+    /// E.g. In case of errors it will retry for 7 times:
+    /// `RCR = 0x0007`
+    #[inline]
+    fn current_retry_count(&mut self) -> Result<RetryCount, Self::Error> {
+        let mut retry_count_register: [u8; 1] = [0];
+        self.read_frame(
+            register::COMMON,
+            register::common::RETRY_COUNT,
+            &mut retry_count_register,
+        )?;
+
+        Ok(RetryCount::from_register(retry_count_register))
+    }
 }
 
 pub struct BusRef<'a, B: Bus>(pub &'a mut B);

--- a/src/device.rs
+++ b/src/device.rs
@@ -8,6 +8,8 @@ use crate::socket::Socket;
 use crate::uninitialized_device::UninitializedDevice;
 use crate::{register, MacAddress};
 
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ResetError<E> {
     SocketsNotReleased,
     Other(E),
@@ -53,9 +55,13 @@ impl<SpiBus: Bus, HostImpl: Host> Device<SpiBus, HostImpl> {
 
     fn clear_mode(&mut self) -> Result<(), SpiBus::Error> {
         // reset bit
-        let mode = [0b10000000];
-        self.bus
-            .write_frame(register::COMMON, register::common::MODE, &mode)?;
+        let reset_mode = register::common::Mode::Reset;
+
+        self.bus.write_frame(
+            register::COMMON,
+            register::common::MODE,
+            &[reset_mode.to_u8()],
+        )?;
         Ok(())
     }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -23,7 +23,7 @@ impl<E> From<E> for ResetError<E> {
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub(crate) struct DeviceState<HostImpl: Host> {
+pub struct DeviceState<HostImpl: Host> {
     host: HostImpl,
     sockets: [u8; 1],
 }
@@ -42,6 +42,10 @@ impl<SpiBus: Bus, HostImpl: Host> Device<SpiBus, HostImpl> {
                 sockets: [0b11111111],
             },
         }
+    }
+
+    pub fn get_state(&self) -> &DeviceState<HostImpl> {
+        &self.state
     }
 
     pub fn reset(mut self) -> Result<UninitializedDevice<SpiBus>, ResetError<SpiBus::Error>> {
@@ -151,6 +155,16 @@ impl<SpiBus: Bus, HostImpl: Host> DeviceRefMut<'_, SpiBus, HostImpl> {
     pub fn release_socket(&mut self, socket: Socket) {
         self.state.sockets.set_bit(socket.index.into(), true);
     }
+
+    // /// RTR (Retry Time-value Register) [R/W] [0x0019 – 0x001A] [0x07D0]
+    // pub fn set_retry_timeout(
+    //     &self,
+    //     code: socketn::Interrupt,
+    // ) -> Result<(), SpiBus::Error> {
+    //     let data = [code as u8];
+    //     self.bus.write_frame(self.register(), socketn::, &data)?;
+    //     Ok(())
+    // }
 
     pub fn gateway(&mut self) -> Result<Ipv4Addr, SpiBus::Error> {
         let mut octets = [0u8; 4];

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -8,6 +8,8 @@ use crate::register;
 use crate::MacAddress;
 use embedded_nal::Ipv4Addr;
 
+pub static UNSPECIFIED_IP: Ipv4Addr = Ipv4Addr::new(0, 0, 0, 0);
+
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct HostConfig {
@@ -24,9 +26,9 @@ impl Default for HostConfig {
     fn default() -> Self {
         Self {
             mac: MacAddress::default(),
-            ip: Ipv4Addr::unspecified(),
-            gateway: Ipv4Addr::unspecified(),
-            subnet: Ipv4Addr::unspecified(),
+            ip: UNSPECIFIED_IP,
+            gateway: UNSPECIFIED_IP,
+            subnet: UNSPECIFIED_IP,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,47 +23,72 @@ pub use uninitialized_device::{InitializeError, UninitializedDevice};
 
 /// Settings for wake on LAN.  Allows the W5500 to optionally emit an interrupt upon receiving a packet
 #[repr(u8)]
-#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum OnWakeOnLan {
     InvokeInterrupt = 0b00100000,
     Ignore = 0b00000000,
 }
 
+/// Ping Block Mode
+///
 /// Settings for ping.  Allows the W5500 to respond to or ignore network ping requests
 #[repr(u8)]
-#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum OnPingRequest {
+    /// 0: Disable Ping block
     Respond = 0b00000000,
+    /// 1 : Enable Ping block
+    ///
+    /// If the bit is ‘1’, it blocks the response to a ping request.
     Ignore = 0b00010000,
 }
 
 /// Use [ConnectionType::PPoE] when talking
 /// to an ADSL modem. Otherwise use [ConnectionType::Ethernet]
 #[repr(u8)]
-#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConnectionType {
     PPoE = 0b00001000,
     Ethernet = 0b00000000,
 }
 
-#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
+/// Force ARP
+///
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum ArpResponses {
+    /// 0 : Disable Force ARP mode
     Cache = 0b00000000,
+    /// 1 : Enable Force ARP mode
+    ///
+    /// In Force ARP mode, It forces on sending ARP Request whenever data is
+    /// sent.
     DropAfterUse = 0b00000010,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Mode {
     pub on_wake_on_lan: OnWakeOnLan,
     pub on_ping_request: OnPingRequest,
     pub connection_type: ConnectionType,
     pub arp_responses: ArpResponses,
+}
+
+impl Mode {
+    pub fn to_u8(self) -> u8 {
+        let mut register = 0;
+        register |= self.on_wake_on_lan as u8;
+        register |= self.on_ping_request as u8;
+        register |= self.connection_type as u8;
+        register |= self.arp_responses as u8;
+
+        register
+    }
 }
 
 impl Default for Mode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod uninitialized_device;
 pub use device::{Device, DeviceRefMut, InactiveDevice};
 pub use host::{Dhcp, Host, HostConfig, Manual};
 pub use net::MacAddress;
+use register::common;
 pub use uninitialized_device::{InitializeError, UninitializedDevice};
 
 // TODO add better docs to all public items, add unit tests.
@@ -80,6 +81,10 @@ pub struct Mode {
 }
 
 impl Mode {
+    pub fn to_register(self) -> [u8; 1] {
+        [self.to_u8()]
+    }
+
     pub fn to_u8(self) -> u8 {
         let mut register = 0;
         register |= self.on_wake_on_lan as u8;
@@ -88,6 +93,12 @@ impl Mode {
         register |= self.arp_responses as u8;
 
         register
+    }
+}
+
+impl From<Mode> for common::Mode {
+    fn from(value: Mode) -> Self {
+        Self::Mode(value)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![allow(unused)]
 #![deny(rustdoc::broken_intra_doc_links)]
 

--- a/src/register.rs
+++ b/src/register.rs
@@ -236,7 +236,7 @@ pub mod socketn {
 
     pub const STATUS: u16 = 0x03;
     #[repr(u8)]
-    #[derive(TryFromPrimitive)]
+    #[derive(TryFromPrimitive, Debug, Copy, Clone)]
     pub enum Status {
         Closed = 0x00,
         Init = 0x13,
@@ -259,6 +259,14 @@ pub mod socketn {
         Closing = 0x1a,
         TimeWait = 0x1b,
         LastAck = 0x1d,
+    }
+
+    #[cfg(feature = "defmt")]
+    impl defmt::Format for Status {
+        fn format(&self, fmt: defmt::Formatter) {
+            // Format as hexadecimal.
+            defmt::write!(fmt, "{:?} ({=u8:#x})", self, *self as u8);
+        }
     }
 
     pub const SOURCE_PORT: u16 = 0x04;

--- a/src/register.rs
+++ b/src/register.rs
@@ -6,6 +6,11 @@ pub mod common {
     use bit_field::BitArray;
 
     pub const MODE: u16 = 0x0;
+
+    /// The common register Mode.
+    ///
+    /// It differs from the [`crate::Mode`] in one key aspect - we can also
+    /// send a reset value to the w5500, instead of only configuring the settings.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum Mode {
@@ -14,6 +19,10 @@ pub mod common {
     }
 
     impl Mode {
+        pub fn to_register(self) -> [u8; 1] {
+            [self.to_u8()]
+        }
+
         pub fn to_u8(self) -> u8 {
             match self {
                 Mode::Reset => 0b10000000,
@@ -22,14 +31,120 @@ pub mod common {
         }
     }
 
+    /// GAR (Gateway IP Address Register) [R/W] [0x0001 – 0x0004] [0x00]
     pub const GATEWAY: u16 = 0x01;
+
+    /// SUBR (Subnet Mask Register) [R/W] [0x0005 – 0x0008] [0x00]
     pub const SUBNET_MASK: u16 = 0x05;
+
+    /// SHAR (Source Hardware Address Register) [R/W] [0x0009 – 0x000E] [0x00]
     pub const MAC: u16 = 0x09;
+
+    /// SIPR (Source IP Address Register) [R/W] [0x000F – 0x0012] [0x00]
     pub const IP: u16 = 0x0F;
+
+    /// INTLEVEL (Interrupt Low Level Timer Register) [R/W] [0x0013 – 0x0014] [0x0000]
+    pub const INTERRUPT_TIMER: u16 = 0x13;
+
+    /// Address: RTR (Retry Time-value Register) [R/W] [0x0019 – 0x001A] [0x07D0]
+    pub const RETRY_TIME: u16 = 0x19;
+
+    /// A Retry Time-value
+    ///
+    /// RTR (Retry Time-value Register) [R/W] [0x0019 – 0x001A] [0x07D0]
+    ///
+    /// From datasheet:
+    ///
+    /// RTR configures the retransmission timeout period. The unit of timeout period is
+    /// 100us and the default of RTR is ‘0x07D0’ or ‘2000’. And so the default timeout period
+    /// is 200ms(100us X 2000).
+    /// During the time configured by RTR, W5500 waits for the peer response to the packet
+    /// that is transmitted by Sn_CR(CONNECT, DISCON, CLOSE, SEND, SEND_MAC, SEND_KEEP
+    /// command). If the peer does not respond within the RTR time, W5500 retransmits the
+    /// packet or issues timeout.
+    ///
+    ///
+    /// > Ex) When timeout-period is set as 400ms, RTR = (400ms / 1ms) X 10 = 4000(0x0FA0)
+    #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub struct RetryTime(pub(crate) u16);
+
+    impl RetryTime {
+        #[inline]
+        pub fn to_u16(&self) -> u16 {
+            self.0
+        }
+
+        #[inline]
+        pub fn to_register(&self) -> [u8; 2] {
+            self.0.to_be_bytes()
+        }
+
+        #[inline]
+        pub fn from_register(register: [u8; 2]) -> Self {
+            Self(u16::from_be_bytes(register))
+        }
+
+        #[inline]
+        pub fn from_millis(milliseconds: u16) -> Self {
+            Self(milliseconds * 10)
+        }
+
+        #[inline]
+        pub fn to_millis(&self) -> u16 {
+            self.0 / 10
+        }
+    }
+
+    impl Default for RetryTime {
+        fn default() -> Self {
+            Self::from_millis(200)
+        }
+    }
+
+    /// RCR (Retry Count Register) [R/W] [0x001B] [0x08]
+    pub const RETRY_COUNT: u16 = 0x1B;
+
+    /// RCR (Retry Count Register) [R/W] [0x001B] [0x08]
+    ///
+    /// For more details check out the rest of the datasheet documentation on the Retry count.
+    ///
+    /// From datasheet:
+    ///
+    /// RCR configures the number of time of retransmission. When retransmission occurs
+    /// as many as ‘RCR+1’, Timeout interrupt is issued (Sn_IR[TIMEOUT] = ‘1’).
+    ///
+    /// > Ex) RCR = 0x0007
+    ///
+    /// The timeout of W5500 can be configurable with RTR and RCR. W5500 has two kind
+    /// timeout such as Address Resolution Protocol (ARP) and TCP retransmission.
+    ///
+    #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    pub struct RetryCount(pub(crate) u8);
+
+    impl RetryCount {
+        #[inline]
+        pub fn to_u8(&self) -> u8 {
+            self.0
+        }
+
+        #[inline]
+        pub fn to_register(&self) -> [u8; 1] {
+            self.0.to_be_bytes()
+        }
+
+        #[inline]
+        pub fn from_register(register: [u8; 1]) -> Self {
+            Self(register[0])
+        }
+    }
+
     pub const PHY_CONFIG: u16 = 0x2E;
     pub const VERSION: u16 = 0x39;
 
     #[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[repr(u8)]
     pub enum PhyOperationMode {
         /// 10BT half-duplex. Auto-negotiation disabled.

--- a/src/register.rs
+++ b/src/register.rs
@@ -169,6 +169,7 @@ pub mod socketn {
         Udp = 0b10,
         MacRaw = 0b100,
     }
+
     /// Socket n Command Register
     ///
     /// `Sn_CR`
@@ -178,7 +179,7 @@ pub mod socketn {
 
     /// Socket n Commands
     ///
-    /// `Sn_CR` regiter
+    /// `Sn_CR` register
     pub enum Command {
         Open = 0x01,
         Listen = 0x02,
@@ -271,7 +272,7 @@ pub mod socketn {
     /// `Sn_TX_FSR`
     ///
     /// Socket n TX Free Size
-    /// 
+    ///
     /// offset (register)
     /// 0x0020 (Sn_TX_FSR0)
     /// 0x0021 (Sn_TX_FSR1)

--- a/src/register.rs
+++ b/src/register.rs
@@ -121,7 +121,7 @@ pub mod common {
     ///
     #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
     #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-    pub struct RetryCount(pub(crate) u8);
+    pub struct RetryCount(pub u8);
 
     impl RetryCount {
         #[inline]

--- a/src/register.rs
+++ b/src/register.rs
@@ -169,8 +169,16 @@ pub mod socketn {
         Udp = 0b10,
         MacRaw = 0b100,
     }
+    /// Socket n Command Register
+    ///
+    /// `Sn_CR`
+    // pub const COMMAND: u16 = 0b0001;
     pub const COMMAND: u16 = 0x01;
     #[repr(u8)]
+
+    /// Socket n Commands
+    ///
+    /// `Sn_CR` regiter
     pub enum Command {
         Open = 0x01,
         Listen = 0x02,
@@ -182,12 +190,37 @@ pub mod socketn {
     }
 
     pub const INTERRUPT: u16 = 0x02;
+    /// | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+    /// | Reserved | Reserved | Reserved | SEND_OK | TIMEOUT | RECV | DISCON | CON |
+    ///
+    /// | Bit | Symbol | Description |
+    /// | 7~5 | Reserved | Reserved |
+    /// | 4 | SENDOK | Sn_IR(SENDOK) | Interrupt Mask |
+    /// | 3 | TIMEOUT | Sn_IR(TIMEOUT) | Interrupt Mask |
+    /// | 2 | RECV | Sn_IR(RECV) | Interrupt Mask |
+    /// | 1 | DISCON | Sn_IR(DISCON) | Interrupt Mask |
+    /// | 0 | CON | Sn_IR(CON) | Interrupt Mask |
     #[repr(u8)]
     pub enum Interrupt {
         All = 0b11111111u8,
-        SendOk = 0b010000u8,
-        Timeout = 0b01000u8,
-        Receive = 0b00100u8,
+        SendOk = 0b10000u8,
+        Timeout = 0b1000u8,
+        Receive = 0b100u8,
+
+        // SendOk = 0b10000u8,
+        // Timeout = 0b1000u8,
+        // /// Receive data
+        // ///
+        // /// bit 2, symbol `RECV`, `Sn_IR(RECV) Interrupt Mask`
+        // Receive = 0b100u8,
+        /// Disconnect
+        ///
+        /// bit 1, symbol `DISCON`, `Sn_IR(DISCON) Interrupt Mask`
+        Disconnect = 0b10u8,
+        /// Connect
+        ///
+        /// bit 0, symbol `CON`, `Sn_IR(CON) Interrupt Mask`
+        Connect = 0b1u8,
     }
 
     pub const STATUS: u16 = 0x03;
@@ -219,17 +252,55 @@ pub mod socketn {
 
     pub const RXBUF_SIZE: u16 = 0x1E;
 
+    /// Socket n TX Buffer Size Register
+    ///
+    /// `Sn_TXBUF_SIZE`
+    ///
+    /// From datasheet:
+    ///
+    /// > .. can be configured with 1,2,4,8, and 16 Kbytes.
+    /// >
+    /// > Although Socket n TX Buffer Block size is initially configured to 2Kbytes, user can
+    /// > be re-configure its size using Sn_TXBUF_SIZE. The total sum of Sn_TXBUF_SIZE
+    /// > cannot be exceed 16Kbytes. When exceeded, the data transmission error is
+    /// > occurred.
     pub const TXBUF_SIZE: u16 = 0x1F;
 
+    /// TX Free Size Register
+    ///
+    /// `Sn_TX_FSR`
+    ///
+    /// Socket n TX Free Size
+    /// 
+    /// offset (register)
+    /// 0x0020 (Sn_TX_FSR0)
+    /// 0x0021 (Sn_TX_FSR1)
     pub const TX_FREE_SIZE: u16 = 0x20;
 
+    /// Socket n TX Read Pointer
+    ///
+    /// offset (register)
+    /// 0x0022 (Sn_TX_RD0)
+    /// 0x0023 (Sn_TX_RD1)
     pub const TX_DATA_READ_POINTER: u16 = 0x22;
 
+    /// Socket n TX Write Pointer
+    ///
+    /// offset (register)
+    /// 0x0024 (Sn_TX_WR0)
+    /// 0x0025 (Sn_TX_WR1)
     pub const TX_DATA_WRITE_POINTER: u16 = 0x24;
 
+    /// Socket n Received Size Register
+    ///
+    /// `Sn_RX_RSR`
     pub const RECEIVED_SIZE: u16 = 0x26;
 
     pub const RX_DATA_READ_POINTER: u16 = 0x28;
 
+    /// Socket n Interrupt Mask
+    ///
+    /// offset (register)
+    /// 0x002C (Sn_IMR)
     pub const INTERRUPT_MASK: u16 = 0x2C;
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -12,6 +12,7 @@ pub struct Socket {
 }
 
 impl Socket {
+    /// 8 sockets available on the w5500
     pub fn new(index: u8) -> Self {
         /*
          * Socket 0 is at address    0x01
@@ -179,9 +180,12 @@ impl Socket {
         Ok(())
     }
 
+    /// Get the received bytes size of the socket's RX buffer.
+    ///
+    /// Section 4.2 of datasheet, Sn_TX_FSR address docs indicate that read must be repeated until two sequential reads are stable
     pub fn get_receive_size<SpiBus: Bus>(&self, bus: &mut SpiBus) -> Result<u16, SpiBus::Error> {
         loop {
-            // Section 4.2 of datasheet, Sn_TX_FSR address docs indicate that read must be repeated until two sequential reads are stable
+            
             let mut sample_0 = [0u8; 2];
             bus.read_frame(self.register(), socketn::RECEIVED_SIZE, &mut sample_0)?;
             let mut sample_1 = [0u8; 2];
@@ -192,6 +196,9 @@ impl Socket {
         }
     }
 
+    /// Get the free TX buffer size still available for this socket.
+    ///
+    /// It's cleared once we `SEND` the buffer over the socket.
     pub fn get_tx_free_size<SpiBus: Bus>(&self, bus: &mut SpiBus) -> Result<u16, SpiBus::Error> {
         let mut data = [0; 2];
         bus.read_frame(self.register(), socketn::TX_FREE_SIZE, &mut data)?;

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -76,6 +76,7 @@ impl Socket {
     ) -> Result<bool, SpiBus::Error> {
         let mut data = [0u8];
         bus.read_frame(self.register(), socketn::INTERRUPT, &mut data)?;
+
         Ok(data[0] & code as u8 != 0)
     }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -185,7 +185,6 @@ impl Socket {
     /// Section 4.2 of datasheet, Sn_TX_FSR address docs indicate that read must be repeated until two sequential reads are stable
     pub fn get_receive_size<SpiBus: Bus>(&self, bus: &mut SpiBus) -> Result<u16, SpiBus::Error> {
         loop {
-            
             let mut sample_0 = [0u8; 2];
             bus.read_frame(self.register(), socketn::RECEIVED_SIZE, &mut sample_0)?;
             let mut sample_1 = [0u8; 2];
@@ -203,5 +202,86 @@ impl Socket {
         let mut data = [0; 2];
         bus.read_frame(self.register(), socketn::TX_FREE_SIZE, &mut data)?;
         Ok(u16::from_be_bytes(data))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::register::*;
+
+    use super::*;
+    #[test]
+    fn test_socket_registers() {
+        // Socket 0
+        {
+            let socket_0 = Socket::new(0);
+
+            assert_eq!(socket_0.register, SOCKET0);
+            assert_eq!(socket_0.tx_buffer, SOCKET0_BUFFER_TX);
+            assert_eq!(socket_0.rx_buffer, SOCKET0_BUFFER_RX);
+        }
+
+        // Socket 1
+        {
+            let socket_1 = Socket::new(1);
+
+            assert_eq!(socket_1.register, SOCKET1);
+            assert_eq!(socket_1.tx_buffer, SOCKET1_BUFFER_TX);
+            assert_eq!(socket_1.rx_buffer, SOCKET1_BUFFER_RX);
+        }
+
+        // Socket 2
+        {
+            let socket_2 = Socket::new(2);
+
+            assert_eq!(socket_2.register, SOCKET2);
+            assert_eq!(socket_2.tx_buffer, SOCKET2_BUFFER_TX);
+            assert_eq!(socket_2.rx_buffer, SOCKET2_BUFFER_RX);
+        }
+
+        // Socket 3
+        {
+            let socket_3 = Socket::new(3);
+
+            assert_eq!(socket_3.register, SOCKET3);
+            assert_eq!(socket_3.tx_buffer, SOCKET3_BUFFER_TX);
+            assert_eq!(socket_3.rx_buffer, SOCKET3_BUFFER_RX);
+        }
+
+        // Socket 4
+        {
+            let socket_4 = Socket::new(4);
+
+            assert_eq!(socket_4.register, SOCKET4);
+            assert_eq!(socket_4.tx_buffer, SOCKET4_BUFFER_TX);
+            assert_eq!(socket_4.rx_buffer, SOCKET4_BUFFER_RX);
+        }
+
+        // Socket 5
+        {
+            let socket_5 = Socket::new(5);
+
+            assert_eq!(socket_5.register, SOCKET5);
+            assert_eq!(socket_5.tx_buffer, SOCKET5_BUFFER_TX);
+            assert_eq!(socket_5.rx_buffer, SOCKET5_BUFFER_RX);
+        }
+
+        // Socket 6
+        {
+            let socket_6 = Socket::new(6);
+
+            assert_eq!(socket_6.register, SOCKET6);
+            assert_eq!(socket_6.tx_buffer, SOCKET6_BUFFER_TX);
+            assert_eq!(socket_6.rx_buffer, SOCKET6_BUFFER_RX);
+        }
+
+        // Socket 7
+        {
+            let socket_7 = Socket::new(7);
+
+            assert_eq!(socket_7.register, SOCKET7);
+            assert_eq!(socket_7.tx_buffer, SOCKET7_BUFFER_TX);
+            assert_eq!(socket_7.rx_buffer, SOCKET7_BUFFER_RX);
+        }
     }
 }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -6,6 +6,17 @@ use crate::socket::Socket;
 use core::fmt::Debug;
 use embedded_nal::{nb, IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4, UdpClientStack, UdpFullStack};
 
+/// W5500 UDP Header
+pub struct UdpHeader {
+    /// The origin socket address (IP address and port).
+    pub origin: SocketAddrV4,
+    /// Length of the UDP packet in bytes.
+    ///
+    /// This may not be equal to the length of the data in the socket buffer if the UDP packet was truncated
+    /// due to small buffer or the size of the internal W5500 RX buffer for the socket.
+    pub len: usize,
+}
+
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct UdpSocket {
@@ -44,41 +55,143 @@ impl UdpSocket {
         Ok(())
     }
 
-    fn send<SpiBus: Bus>(
+    fn send_all<SpiBus: Bus>(
         &self,
         bus: &mut SpiBus,
         send_buffer: &[u8],
     ) -> NbResult<(), UdpSocketError<SpiBus::Error>> {
-        // TODO increase longevity by cycling through buffer, instead of always writing to 0
-        // TODO ensure write is currently possible
+        let mut free_size = self.socket.get_tx_free_size(bus)?;
+
+        // ensure write is currently possible
+        if free_size == 0 {
+            return Err(NbError::WouldBlock);
+        }
+
+        // on the first send, we rely on the free TX size and the length of the send_buffer
+        let mut total_sent = 0;
+
+        // if we've sent all bytes, exit the loop
+        while total_sent != send_buffer.len() {
+            let remaining_bytes = &send_buffer[total_sent..];
+
+            // take the smaller value out of the free buffer length and
+            // the length of the remaining bytes to be send
+            let write_len = (free_size as usize).min(remaining_bytes.len());
+            // let end_index= total_sent + write_len;
+            let send_batch = &remaining_bytes[..write_len];
+
+            // but on consequent send calls, we leave that to send
+            let sent = self.send(bus, send_batch)?;
+
+            total_sent += sent;
+
+            // update the `free_size` of the TX buffer after we've sent some bytes
+            free_size = self.socket.get_tx_free_size(bus)?;
+        }
+
+        Ok(())
+    }
+
+    /// Send buffer should be less than [`u16::MAX`].
+    ///
+    /// # Returns
+    ///
+    /// The amount of bytes that were sent. The caller should make sure to
+    /// check and send the rest of the `send_buffer` data.
+    fn send<SpiBus: Bus>(
+        &self,
+        bus: &mut SpiBus,
+        send_buffer: &[u8],
+    ) -> NbResult<usize, UdpSocketError<SpiBus::Error>> {
+        let free_size = self.socket.get_tx_free_size(bus)?;
+
+        // ensure write is currently possible
+        if free_size == 0 {
+            // TODO: better error for no more space in TX buffer
+            return Err(NbError::WouldBlock);
+        }
+
+        // check the size of the data buffer and limit it accordingly to the available (free) TX buffer size.
+        let write_data = if send_buffer.len() < free_size as usize {
+            send_buffer
+        } else {
+            &send_buffer[..(free_size as usize)]
+        };
+
+        #[cfg(feature = "defmt")]
+        defmt::debug!(
+            "Prepare for sending {} bytes out of {} ({} free TX buffer size)",
+            write_data.len(),
+            send_buffer.len(),
+            free_size,
+        );
+        // Append the data to the write buffer after the current write pointer.
+        let write_pointer = self.socket.get_tx_write_pointer(bus)?;
+
+        // #[cfg(feature = "defmt")]
+        // defmt::debug!("TX read at {} TX Write at {}", self.socket.get_tx_read_pointer(bus)?, write_pointer);
+
+        #[cfg(feature = "defmt")]
+        defmt::debug!("TX Buffer at {}, write pointer: {}", self.socket.tx_buffer(), write_pointer);
+        
+        // Write data into the buffer and update the writer pointer.
+        bus.write_frame(self.socket.tx_buffer(), write_pointer, write_data)?;
+        // this will wrap the pointer accordingly to the TX `free_size`.
+        // safe to cast to `u16` because the maximum buffer size in w5500 is 16 KB!
         self.socket
-            .set_tx_read_pointer(bus, 0)
-            .and_then(|_| bus.write_frame(self.socket.tx_buffer(), 0, send_buffer))
-            .and_then(|_| {
-                self.socket
-                    .set_tx_write_pointer(bus, send_buffer.len() as u16)
-            })
-            .and_then(|_| self.socket.command(bus, socketn::Command::Send))?;
+            .set_tx_write_pointer(bus, write_pointer.wrapping_add(write_data.len() as u16))?;
+
+        #[cfg(feature = "defmt")]
+        defmt::debug!("NEW TX Write at {}", write_pointer.wrapping_add(write_data.len() as u16));
+
+        // Send the data.
+        self.socket.command(bus, socketn::Command::Send)?;
+
+        // #[cfg(feature = "defmt")]
+        // defmt::debug!("NEW TX read at {} TX Write at {}", self.socket.get_tx_read_pointer(bus)?, write_pointer.wrapping_add(write_data.len() as u16));
+
+        // wait for reaching out the TX write pointer (we've sent all the data in the buffer)
+        // #[cfg(feature = "defmt")]
+        // for i in 0..10 {
+        //     let tx_read = self.socket.get_tx_read_pointer(bus)?;
+        //     let tx_write = self.socket.get_tx_write_pointer(bus)?;
+
+        //     defmt::debug!("TX Read at {} TX Write at {}", tx_read, tx_write);
+        // }
 
         loop {
-            if self.socket.get_tx_read_pointer(bus)? == self.socket.get_tx_write_pointer(bus)? {
+            let tx_read = self.socket.get_tx_read_pointer(bus)?;
+            let tx_write = self.socket.get_tx_write_pointer(bus)?;
+            if tx_read == tx_write {
                 if self.socket.has_interrupt(bus, socketn::Interrupt::SendOk)? {
+                    #[cfg(feature = "defmt")]
+                    defmt::debug!("has interrupt for SendOk");
+
                     self.socket
                         .reset_interrupt(bus, socketn::Interrupt::SendOk)?;
-                    return Ok(());
+                    return Ok(write_data.len());
                 } else if self
                     .socket
                     .has_interrupt(bus, socketn::Interrupt::Timeout)?
                 {
+                    #[cfg(feature = "defmt")]
+                    defmt::debug!("has interrupt for Timeout");
+
                     self.socket
                         .reset_interrupt(bus, socketn::Interrupt::Timeout)?;
                     return Err(NbError::Other(UdpSocketError::WriteTimeout));
                 }
             }
         }
+
+        Ok(write_data.len())
     }
 
     /// Sets a new destination before performing the send operation.
+    ///
+    /// # Returns
+    /// The amount of bytes that were sent. The caller should make sure to
+    /// check and send the rest of the `send_buffer` data.
     fn send_to<SpiBus: Bus>(
         &mut self,
         bus: &mut SpiBus,
@@ -86,17 +199,34 @@ impl UdpSocket {
         send_buffer: &[u8],
     ) -> NbResult<(), UdpSocketError<SpiBus::Error>> {
         self.set_destination(bus, remote)?;
-        self.send(bus, send_buffer)
+
+        self.send_all(bus, send_buffer)
     }
 
     /// Receive data and mutate the `receive_buffer`.
     ///
+    /// `receive_buffer` will only be used for receiving the packet data.
+    /// The [`UdpHeader`]'s - [`SocketAddrV4`] and `len` will be read separately from the buffer.
+    /// Note that the header is part of the internal RX buffer so `receive_buffer` can be smaller
+    /// in size by 8 bytes.
+    ///
+    /// If the packet len is larger than the internal RX buffer, the data will be truncated.
+    ///
     /// If [`Interrupt::Receive`] is not set, it will always return [`NbError::WouldBlock`].
+    ///
+    ///
+    /// Packet frame, as described in W5200 docs section 5.2.2.1:
+    ///
+    /// ```text
+    /// |<-- read_pointer                                 read_pointer + received_size -->|
+    /// | Destination IP Address | Destination Port | Byte Size of DATA | Actual DATA ... |
+    /// |    --- 4 Bytes ---     |  --- 2 Bytes --- |  --- 2 Bytes ---  |      ....       |
+    /// ```
     fn receive<SpiBus: Bus>(
         &mut self,
         bus: &mut SpiBus,
         receive_buffer: &mut [u8],
-    ) -> NbResult<(usize, SocketAddr), UdpSocketError<SpiBus::Error>> {
+    ) -> NbResult<(usize, UdpHeader), UdpSocketError<SpiBus::Error>> {
         if !self
             .socket
             .has_interrupt(bus, socketn::Interrupt::Receive)?
@@ -104,38 +234,69 @@ impl UdpSocket {
             return Err(NbError::WouldBlock);
         }
 
-        /*
-         * Packet frame, as described in W5200 docs section 5.2.2.1
-         * |<-- read_pointer                                 read_pointer + received_size -->|
-         * | Destination IP Address | Destination Port | Byte Size of DATA | Actual DATA ... |
-         * |    --- 4 Bytes ---     |  --- 2 Bytes --- |  --- 2 Bytes ---  |      ....       |
-         */
-        // TODO loop until RX received size stops changing, or it's larger than
-        // receive_buffer.len()
+        let rx_size = self.socket.get_receive_size(bus)? as usize;
+        if rx_size == 0 {
+            return Err(NbError::WouldBlock);
+        }
+        let buffer_size = receive_buffer.len();
+        if buffer_size == 0 {
+            return Err(NbError::Other(UdpSocketError::BufferOverflow));
+        }
+
+        // the amount of bytes we are able to read, the rest will be truncated by setting the RX read pointer
+        // to the end of the RX buffer.
+        let read_size = rx_size.min(buffer_size);
+
+        let read_buffer = &mut receive_buffer[..read_size];
+
+        // Read from the RX ring buffer.
         let read_pointer = self.socket.get_rx_read_pointer(bus)?;
+
         let mut header = [0u8; 8];
+        // read enough data for the headers - remote SocketAddr & Packet size
         bus.read_frame(self.socket.rx_buffer(), read_pointer, &mut header)?;
-        let remote = SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(header[0], header[1], header[2], header[3])),
+        let origin_addr = SocketAddrV4::new(
+            Ipv4Addr::new(header[0], header[1], header[2], header[3]),
             u16::from_be_bytes([header[4], header[5]]),
         );
-        let packet_size = u16::from_be_bytes([header[6], header[7]]).into();
-        let data_read_pointer = read_pointer + 8;
-        // TODO handle buffer overflow
-        bus.read_frame(
-            self.socket.rx_buffer(),
-            data_read_pointer,
-            &mut receive_buffer[0..packet_size],
-        )?;
 
-        let tx_write_pointer = self.socket.get_tx_write_pointer(bus)?;
+        let packet_len: usize = u16::from_be_bytes([header[6], header[7]]).into();
+        let udp_header = UdpHeader {
+            origin: origin_addr,
+            len: packet_len,
+        };
+
+        let data_read_pointer = read_pointer.wrapping_add(8);
+
+        /// read the rest of the packet's data that can fit in the buffer
+        bus.read_frame(self.socket.rx_buffer(), read_pointer, read_buffer)?;
+
+        // Set the RX point after the `rx_size`, truncating any bytes that the
+        // `receiving_buffer` was not able to fit
+        // it's safe to cast `rx_size` to u16 as the maximum RX buffer is
+        // 16 KB (`16384` maximum value) < u16::MAX
         self.socket
-            .set_rx_read_pointer(bus, tx_write_pointer)
-            .and_then(|_| self.socket.command(bus, socketn::Command::Receive))
-            .and_then(|_| self.socket.command(bus, socketn::Command::Open))?;
+            .set_rx_read_pointer(bus, read_pointer.wrapping_add(rx_size as u16))?;
+
+        // > RECV completes the processing of the received data in Socket n RX
+        // > Buffer by using a RX read pointer register (Sn_RX_RD).
+        self.socket.command(bus, socketn::Command::Receive)?;
+        // TODO: is this command `Open` really necessary if the socket is already set as Open?
+        self.socket.command(bus, socketn::Command::Open)?;
+
+        // Reset the Receive interrupt
         self.socket
             .reset_interrupt(bus, socketn::Interrupt::Receive)?;
-        Ok((packet_size, remote))
+
+        #[cfg(feature = "defmt")]
+        defmt::debug!(
+            "Received {} bytes of maximum {} RX buffer size from packet with length {}",
+            read_size,
+            rx_size,
+            packet_len
+        );
+
+        Ok((read_size, udp_header))
     }
 
     fn close<SpiBus: Bus>(&self, bus: &mut SpiBus) -> Result<(), UdpSocketError<SpiBus::Error>> {
@@ -156,6 +317,10 @@ impl UdpSocket {
 pub enum UdpSocketError<E: Debug> {
     NoMoreSockets,
     UnsupportedAddress,
+    /// Reading the entire packet will cause the buffer to overflow.
+    ///
+    /// Use a larger than the packet size buffer.
+    BufferOverflow,
     Other(#[cfg_attr(feature = "defmt", defmt(Debug2Format))] E),
     WriteTimeout,
 }
@@ -268,7 +433,8 @@ where
     }
 
     fn send(&mut self, socket: &mut Self::UdpSocket, buffer: &[u8]) -> nb::Result<(), Self::Error> {
-        socket.send(&mut self.bus, buffer)?;
+        socket.send_all(&mut self.bus, buffer)?;
+
         Ok(())
     }
 
@@ -277,7 +443,9 @@ where
         socket: &mut Self::UdpSocket,
         buffer: &mut [u8],
     ) -> nb::Result<(usize, SocketAddr), Self::Error> {
-        Ok(socket.receive(&mut self.bus, buffer)?)
+        let (received, udp_header) = socket.receive(&mut self.bus, buffer)?;
+
+        Ok((received, SocketAddr::V4(udp_header.origin)))
     }
 
     fn close(&mut self, socket: Self::UdpSocket) -> Result<(), Self::Error> {
@@ -331,4 +499,10 @@ where
             Err(nb::Error::Other(Self::Error::UnsupportedAddress))
         }
     }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn send_all_with_data_overflowing_the_tx_buffer() {}
 }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -283,7 +283,7 @@ impl UdpSocket {
             return Ok(());
         }
 
-        return Err(NbError::WouldBlock);
+        Err(NbError::WouldBlock)
     }
 
     /// Sets a new destination before performing the send operation.

--- a/src/uninitialized_device.rs
+++ b/src/uninitialized_device.rs
@@ -108,14 +108,18 @@ impl<SpiBus: Bus> UninitializedDevice<SpiBus> {
         Ok(Device::new(self.bus, host))
     }
 
+    /// Get the currently set Retry Time-value Register.
+    ///
     /// RTR (Retry Time-value Register) [R/W] [0x0019 – 0x001A] [0x07D0]
     ///
     /// E.g. 4000 = 400ms
     #[inline]
     pub fn current_retry_timeout(&mut self) -> Result<RetryTime, SpiBus::Error> {
-        Ok(self.bus.current_retry_timeout()?)
+        self.bus.current_retry_timeout()
     }
 
+    /// Set a new value for the Retry Time-value Register.
+    ///
     /// RTR (Retry Time-value Register) [R/W] [0x0019 – 0x001A] [0x07D0]
     ///
     /// # Example
@@ -129,10 +133,13 @@ impl<SpiBus: Bus> UninitializedDevice<SpiBus> {
     /// let four_hundred_ms = RetryTime::from_millis(400);
     /// assert_eq!(four_hundred_ms.to_u16(), 4000);
     /// ```
+    #[inline]
     pub fn set_retry_timeout(&mut self, retry_time_value: RetryTime) -> Result<(), SpiBus::Error> {
         self.bus.set_retry_timeout(retry_time_value)
     }
 
+    /// Get the current Retry Count Register value.
+    ///
     /// RCR (Retry Count Register) [R/W] [0x001B] [0x08]
     ///
     /// E.g. In case of errors it will retry for 7 times:
@@ -142,6 +149,10 @@ impl<SpiBus: Bus> UninitializedDevice<SpiBus> {
         self.bus.current_retry_count()
     }
 
+    /// Set a new value for the Retry Count register.
+    ///
+    /// RCR (Retry Count Register) [R/W] [0x001B] [0x08]
+    #[inline]
     pub fn set_retry_count(&mut self, retry_count: RetryCount) -> Result<(), SpiBus::Error> {
         self.bus.set_retry_count(retry_count)
     }


### PR DESCRIPTION
Fixes #44
Fixes #46 
~I'm opening this Draft PR because I cannot figure why I cannot send data when using more than 1 socket.~ (see #44 )

Single socket sending works but the moment I take a second socket and try to send data with it, it never receives a `SendOk` interrupt.

I've managed to work and fix some outstanding TODOs regarding UDP and I was facing some issues when sending data.
One problem I found was that `tx` buffer was referenced in the context of `rx`

~Any clues what is happening with multiple sockets?! Is it a wrong registry or smth else?~

Please check the Changelog as there have been multiple improvements including the feature to set and retrieve Retry Time and Retry Count registers.