### PR TITLE
Renaming trait function names, cleaning up docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `defmt` features for enabling `defmt::Format` to most structs and errors by [@elpiel](https://github.com/elpiel) ([#39](https://github.com/kellerkindt/w5500/issues/39))
+- Fixed an issue where internal function names were conflicting with trait names by [@ryan-summers](https://github.com/ryan-summers) ([#36](https://github.com/kellerkindt/w5500/issues/36))
 
 ## [0.4.1] - January 2nd, 2023
 

--- a/README.md
+++ b/README.md
@@ -29,49 +29,76 @@ of the SPI implementation.  It must be set up to work as the W5500 chip requires
 * Clock Phase: Sample leading edge
 * Clock speed: 33MHz maximum
 
-Initialization and usage of owned `Device`:
-```rust
-    let mut spi = ...; // SPI interface to use
-    let mut cs : OutputPin = ...; // chip select
+```rust,no_run
+use embedded_nal::{IpAddr, Ipv4Addr, SocketAddr, UdpClientStack};
+#
+# struct Mock;
+# 
+# impl embedded_hal::blocking::spi::Transfer<u8> for Mock {
+#     type Error = ();
+# 
+#     fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
+#         words[0] = 0x04;
+#         Ok(words)
+#     }
+# }
+# 
+# impl embedded_hal::spi::FullDuplex<u8> for Mock {
+#     type Error = ();
+# 
+#     fn read(&mut self) -> nb::Result<u8, Self::Error> {
+#         Ok(0)
+#     }
+# 
+#     fn send(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+#         Ok(())
+#     }
+# }
+# 
+# impl embedded_hal::blocking::spi::Write<u8> for Mock {
+#     type Error = ();
+# 
+#     fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+#         Ok(())
+#     }
+# }
+# 
+# impl embedded_hal::digital::v2::OutputPin for Mock {
+#     type Error = ();
+# 
+#     fn set_low(&mut self) -> Result<(), Self::Error> {
+#         Ok(())
+#     }
+# 
+#     fn set_high(&mut self) -> Result<(), Self::Error> {
+#         Ok(())
+#     }
+# }
 
-    // alternative                     FourWireRef::new(&mut spi, &mut cs)
-    let device = UninitializedDevice::new(FourWire::new(spi, cs))
-            .initialize_manual(
-                    MacAddress::new(0, 1, 2, 3, 4, 5),
-                    Ipv4Addr::new(192, 168, 86, 79),
-                    Mode::default()
-            ).unwrap();
+let mut spi = Mock;
+let mut cs = Mock;
 
-    let socket = device.socket();
-    socket.connect(
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 86, 38)), 8000),
-    ).unwrap();
-    block!(interface.send(&mut socket, &[104, 101, 108, 108, 111, 10]));
-    device.close(socket);
+let mut device = w5500::UninitializedDevice::new(w5500::bus::FourWire::new(spi, cs))
+        .initialize_manual(
+                w5500::MacAddress::new(0, 1, 2, 3, 4, 5),
+                Ipv4Addr::new(192, 168, 86, 79),
+                w5500::Mode::default()
+        ).unwrap();
 
-    // optional
-    let (spi_bus, inactive_device) = device.deactivate();
-```
+// Allocate a UDP socket to send data with
+let mut socket = device.socket().unwrap();
 
-Usage of borrowed SPI-Bus and previously initialized `Device`:
-```rust
-    let mut spi = ...; // SPI interface to use
-    let mut cs: OutputPin = ...; // chip select
+// Connect the socket to the IP address and port we want to send to.
+device.connect(&mut socket,
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 86, 38)), 8000),
+).unwrap();
 
-    let mut device: Option<InactiveDevice<..>> = ...; // maybe: previously initialized device
-    let mut socket: Option<Socket> = ...; // maybe: previously opened socket
-    
-    if let (Some(socket), Some(device)) = (socket.as_mut(), device.as_mut()) {
-        let mut buffer = [0u8; 1024];
-        match device
-            // scoped activation & usage of the SPI bus without move
-            .activate_ref(FourWireRef::new(&mut spi, &mut cs))
-            .receive(socket, &mut buffer)
-        {
-            Ok(..) => todo!(),
-            Err(..) => todo!(),
-        }
-    }
+// Send the data
+nb::block!(device.send(&mut socket, &[104, 101, 108, 108, 111, 10]));
+
+// Optionally close the socket and deactivate the device
+device.close(socket);
+let (spi_bus, inactive_device) = device.deactivate();
 ```
 ## Todo
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![allow(unused)]
 #![deny(rustdoc::broken_intra_doc_links)]
-#[doc = include_str!("../README.md")]
+#![doc = include_str!("../README.md")]
 
 pub mod bus;
 mod device;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![allow(unused)]
 #![deny(rustdoc::broken_intra_doc_links)]
+#[doc = include_str!("../README.md")]
 
 pub mod bus;
 mod device;

--- a/src/register.rs
+++ b/src/register.rs
@@ -13,7 +13,7 @@ pub mod common {
     pub const PHY_CONFIG: u16 = 0x2E;
     pub const VERSION: u16 = 0x39;
 
-    #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+    #[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
     #[repr(u8)]
     pub enum PhyOperationMode {
         /// 10BT half-duplex. Auto-negotiation disabled.
@@ -29,18 +29,13 @@ pub mod common {
         /// Power down mode.
         PowerDown = 0b110_000,
         /// All capable. Auto-negotiation enabled.
+        #[default]
         Auto = 0b111_000,
     }
 
     impl From<PhyOperationMode> for u8 {
         fn from(val: PhyOperationMode) -> u8 {
             val as u8
-        }
-    }
-
-    impl Default for PhyOperationMode {
-        fn default() -> PhyOperationMode {
-            PhyOperationMode::Auto
         }
     }
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -138,7 +138,10 @@ impl UdpSocket {
         Ok((packet_size, remote))
     }
 
-    fn socket_close<SpiBus: Bus>(&self, bus: &mut SpiBus) -> Result<(), UdpSocketError<SpiBus::Error>> {
+    fn socket_close<SpiBus: Bus>(
+        &self,
+        bus: &mut SpiBus,
+    ) -> Result<(), UdpSocketError<SpiBus::Error>> {
         self.socket.set_mode(bus, socketn::Protocol::Closed)?;
         self.socket.command(bus, socketn::Command::Close)?;
         Ok(())

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -44,7 +44,7 @@ impl UdpSocket {
         Ok(())
     }
 
-    fn _send<SpiBus: Bus>(
+    fn socket_send<SpiBus: Bus>(
         &self,
         bus: &mut SpiBus,
         send_buffer: &[u8],
@@ -79,20 +79,20 @@ impl UdpSocket {
     }
 
     /// Sets a new destination before performing the send operation.
-    fn _send_to<SpiBus: Bus>(
+    fn socket_send_to<SpiBus: Bus>(
         &mut self,
         bus: &mut SpiBus,
         remote: SocketAddrV4,
         send_buffer: &[u8],
     ) -> NbResult<(), UdpSocketError<SpiBus::Error>> {
         self.set_destination(bus, remote)?;
-        self._send(bus, send_buffer)
+        self.socket_send(bus, send_buffer)
     }
 
     /// Receive data and mutate the `receive_buffer`.
     ///
     /// If [`Interrupt::Receive`] is not set, it will always return [`NbError::WouldBlock`].
-    fn _receive<SpiBus: Bus>(
+    fn socket_receive<SpiBus: Bus>(
         &mut self,
         bus: &mut SpiBus,
         receive_buffer: &mut [u8],
@@ -138,7 +138,7 @@ impl UdpSocket {
         Ok((packet_size, remote))
     }
 
-    fn _close<SpiBus: Bus>(&self, bus: &mut SpiBus) -> Result<(), UdpSocketError<SpiBus::Error>> {
+    fn socket_close<SpiBus: Bus>(&self, bus: &mut SpiBus) -> Result<(), UdpSocketError<SpiBus::Error>> {
         self.socket.set_mode(bus, socketn::Protocol::Closed)?;
         self.socket.command(bus, socketn::Command::Close)?;
         Ok(())
@@ -267,7 +267,7 @@ where
     }
 
     fn send(&mut self, socket: &mut Self::UdpSocket, buffer: &[u8]) -> nb::Result<(), Self::Error> {
-        socket._send(&mut self.bus, buffer)?;
+        socket.socket_send(&mut self.bus, buffer)?;
         Ok(())
     }
 
@@ -276,11 +276,11 @@ where
         socket: &mut Self::UdpSocket,
         buffer: &mut [u8],
     ) -> nb::Result<(usize, SocketAddr), Self::Error> {
-        Ok(socket._receive(&mut self.bus, buffer)?)
+        Ok(socket.socket_receive(&mut self.bus, buffer)?)
     }
 
     fn close(&mut self, socket: Self::UdpSocket) -> Result<(), Self::Error> {
-        socket._close(&mut self.bus)?;
+        socket.socket_close(&mut self.bus)?;
         self.release_socket(socket.socket);
         Ok(())
     }
@@ -327,7 +327,7 @@ where
             return Err(nb::Error::Other(Self::Error::UnsupportedAddress))
         };
 
-        socket._send_to(&mut self.bus, remote, buffer)?;
+        socket.socket_send_to(&mut self.bus, remote, buffer)?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR fixes #36 by renaming some of the internal function names. It also cleans up the docs so that they get run automatically by `cargo test`