### PR TITLE
Allow interrupt-driven MACRAW operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where internal function names were conflicting with trait names by [@ryan-summers](https://github.com/ryan-summers) ([#36](https://github.com/kellerkindt/w5500/issues/36))
 - Add `RetryTime` and `RetryCount` common register methods to `Device` and `UninitializedDevice` by [@elpiel](https://github.com/elpiel) ([#54][PR54])
 - Add `Udp::get_port` and `Udp::set_port` by [@elpiel](https://github.com/elpiel) ([#57](https://github.com/kellerkindt/w5500/pull/57))
+- Add `RawDevice::enable_interrupts` (and `clear_interrupts`, `disable_interrupts`) for interrupt-driven MACRAW mode by [@pdh11](https://github.com/pdh11) ([#60](https://github.com/kellerkindt/w5000/pull/60))
 
 ### Fixed
 

--- a/src/raw_device.rs
+++ b/src/raw_device.rs
@@ -46,7 +46,7 @@ impl<SpiBus: Bus> RawDevice<SpiBus> {
     ///             For instance, pass `Interrupt::Receive` to get interrupts
     ///             on packet reception only.
     ///
-    pub fn enable_interrupt(&mut self, which: u8) -> Result<(), SpiBus::Error> {
+    pub fn enable_interrupts(&mut self, which: u8) -> Result<(), SpiBus::Error> {
         self.raw_socket.set_interrupt_mask(&mut self.bus, which)?;
         self.bus.write_frame(
             register::COMMON,
@@ -64,14 +64,14 @@ impl<SpiBus: Bus> RawDevice<SpiBus> {
     /// can mask the interrupt *at microcontroller level* in the
     /// interrupt handler, then call this from thread mode before
     /// unmasking again.
-    pub fn clear_interrupt(&mut self) -> Result<(), SpiBus::Error> {
+    pub fn clear_interrupts(&mut self) -> Result<(), SpiBus::Error> {
         self.raw_socket
             .reset_interrupt(&mut self.bus, register::socketn::Interrupt::All)
     }
 
     /// Disable all interrupts
     ///
-    pub fn disable_interrupt(&mut self) -> Result<(), SpiBus::Error> {
+    pub fn disable_interrupts(&mut self) -> Result<(), SpiBus::Error> {
         self.bus.write_frame(
             register::COMMON,
             register::common::SOCKET_INTERRUPT_MASK,

--- a/src/register.rs
+++ b/src/register.rs
@@ -22,6 +22,9 @@ pub mod common {
     /// Register: INTLEVEL (Interrupt Low Level Timer Register) [R/W] [0x0013 – 0x0014] [0x0000]
     pub const INTERRUPT_TIMER: u16 = 0x13;
 
+    /// Register: SIMR (Socket Interrupt Mask Register) [R/W] [0x0018] [0x00]
+    pub const SOCKET_INTERRUPT_MASK: u16 = 0x18;
+
     /// Register: RTR (Retry Time-value Register) [R/W] [0x0019 – 0x001A] [0x07D0]
     pub const RETRY_TIME: u16 = 0x19;
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -223,7 +223,7 @@ impl<SpiBus: Bus, HostImpl: Host> TcpClientStack for DeviceRefMut<'_, SpiBus, Ho
         remote: SocketAddr,
     ) -> nb::Result<(), Self::Error> {
         let SocketAddr::V4(remote) = remote else {
-            return Err(nb::Error::Other(Self::Error::UnsupportedAddress))
+            return Err(nb::Error::Other(Self::Error::UnsupportedAddress));
         };
         // TODO dynamically select a random port
         socket.open(&mut self.bus, 49849 + u16::from(socket.socket.index))?; // chosen by fair dice roll.

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -534,7 +534,7 @@ where
         remote: SocketAddr,
     ) -> Result<(), Self::Error> {
         let SocketAddr::V4(remote) = remote else {
-            return Err(Self::Error::UnsupportedAddress)
+            return Err(Self::Error::UnsupportedAddress);
         };
         socket.open(&mut self.bus)?;
         socket.set_destination(&mut self.bus, remote)?;
@@ -602,7 +602,7 @@ where
         buffer: &[u8],
     ) -> nb::Result<(), Self::Error> {
         let SocketAddr::V4(remote) = remote else {
-            return Err(nb::Error::Other(Self::Error::UnsupportedAddress))
+            return Err(nb::Error::Other(Self::Error::UnsupportedAddress));
         };
 
         socket.socket_send_to(&mut self.bus, remote, buffer)?;


### PR DESCRIPTION
This commit adds methods to RawDevice that enable interrupt-driven operation. The enable_interrupt() method sets up SIMR so that socket-level (internal) interrupts on Socket 0 cause chip-level (external) interrupts (and as a convenience also sets S0_IR as required). The disable_interrupt() method reverses those changes. The clear_interrupt() method acknowledges all interrupts and is intended to be called from the interrupt handler (or from thread mode soon afterwards).

There is no change to existing functionality or operation if enable_interrupt() is never called.

I did see PR#34 before filing this, but that change is focused on TCP and UDP sockets, and my use case is MACRAW mode.

Tested on a W5500-Pico-EVB board with the RP2040 successfully receiving and acting on active-low GPIO interrupts from W5500 via the INTn signal on W5500 pin 36.