### PR TITLE
Preparing for 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - July 5th, 2024
+
 ### Changed
 - [breaking] The driver now uses the v1.0 of the `embedded-hal` traits.
 - [breaking] The `FourWireRef` bus and `DeviceRefMut` have been removed in favor of using

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "w5500"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Michael Watzko <michael@watzko.de>", "Jonah Dahlquist <hi@jonah.name>", "Ryan Summers <ryan.summers@vertigo-designs.com"]
 repository = "https://github.com/kellerkindt/w5500.git"
 description = "W5500 IoT Controller implementation."


### PR DESCRIPTION
Prepares for a 0.5.0 release of the `w5500` package to crates-io and Github