### PR TITLE
Make `DeviceState` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ mod uninitialized_device;
 
 #[doc(inline)]
 pub use self::{
-    device::Device,
+    device::{Device, DeviceState},
     host::{Dhcp, Host, HostConfig, Manual},
     net::MacAddress,
     uninitialized_device::{InitializeError, UninitializedDevice},


### PR DESCRIPTION
Hi,

At the moment it is not possible to wrap a `Device` in a struct, which is desirable if trying to abstract away some of the SPI implementation details from other parts of one's code. This is because `DeviceState` is not public, so it can't be part of the type signature of the struct. Example as follows:

```
pub struct MyDeviceWrapper {
    device: Device<FourWire<MySpiDevice>, DeviceState<Manual>>, // `DeviceState` isn't publicly accessible
}
```

Happy to be told I'm missing something obvious if there's a better way to do the above without the change in this PR